### PR TITLE
Add issuer to options

### DIFF
--- a/src/Otp/GoogleAuthenticator.php
+++ b/src/Otp/GoogleAuthenticator.php
@@ -87,6 +87,12 @@ class GoogleAuthenticator
             $otpauth .= '&period=' . $options['period'];
         }
 
+        // issuer
+        // Defaults to none
+        if (array_key_exists('issuer', $options)) {
+            $otpauth .= '&issuer=' . $options['issuer'];
+        }
+
         return $otpauth;
     }
 


### PR DESCRIPTION
Add the issuer argument to the options. [See here](https://code.google.com/p/google-authenticator/wiki/KeyUriFormat).

    GoogleAuthenticator::getQrCodeUrl('totp', 'Example:email@example.com', $secret, null, array('issuer' => 'Example'));

![tfa](https://cloud.githubusercontent.com/assets/1782761/5158397/d860dfc0-733b-11e4-9e82-852c3e3e4ece.png)