### PR TITLE
Fixed code to follow Key Uri Format according to spec

### DIFF
--- a/src/Otp/GoogleAuthenticator.php
+++ b/src/Otp/GoogleAuthenticator.php
@@ -50,6 +50,11 @@ class GoogleAuthenticator
             throw new \InvalidArgumentException('Label has to be one or more printable characters');
         }
 
+        $parts = explode(':', $label);
+        if (count($parts) > 2) {
+        	throw new \InvalidArgumentException('Account name contains illegal colon characters');
+        }
+
         // Secret needs to be here
         if (strlen($secret) < 1) {
             throw new \InvalidArgumentException('No secret present');
@@ -61,10 +66,10 @@ class GoogleAuthenticator
         }
 
         // This is the base, these are at least required
-        $otpauth = 'otpauth://' . $type . '/' . $label . '?secret=' . $secret;
+        $otpauth = 'otpauth://' . $type . '/' . str_replace(array(':', ' '), array('%3A', '%20'), $label) . '?secret=' . rawurlencode($secret);
 
         if ($type == 'hotp' && !is_null($counter)) {
-            $otpauth .= '&counter=' . $counter;
+            $otpauth .= '&counter=' . rawurlencode($counter);
         }
 
         // Now check the options array
@@ -72,25 +77,25 @@ class GoogleAuthenticator
         // algorithm (currently ignored by Authenticator)
         // Defaults to SHA1
         if (array_key_exists('algorithm', $options)) {
-            $otpauth .= '&algorithm=' . $options['algorithm'];
+            $otpauth .= '&algorithm=' . rawurlencode($options['algorithm']);
         }
 
         // digits (currently ignored by Authenticator)
         // Defaults to 6
         if (array_key_exists('digits', $options)) {
-            $otpauth .= '&digits=' . $options['digits'];
+            $otpauth .= '&digits=' . rawurlencode($options['digits']);
         }
 
         // period, only for totp (currently ignored by Authenticator)
         // Defaults to 30
         if ($type == 'totp' && array_key_exists('period', $options)) {
-            $otpauth .= '&period=' . $options['period'];
+            $otpauth .= '&period=' . rawurlencode($options['period']);
         }
 
         // issuer
         // Defaults to none
         if (array_key_exists('issuer', $options)) {
-            $otpauth .= '&issuer=' . $options['issuer'];
+            $otpauth .= '&issuer=' . rawurlencode($options['issuer']);
         }
 
         return $otpauth;

--- a/src/Otp/GoogleAuthenticator.php
+++ b/src/Otp/GoogleAuthenticator.php
@@ -50,8 +50,7 @@ class GoogleAuthenticator
             throw new \InvalidArgumentException('Label has to be one or more printable characters');
         }
 
-        $parts = explode(':', $label);
-        if (count($parts) > 2) {
+        if (substr_count($label, ':') > 2) {
         	throw new \InvalidArgumentException('Account name contains illegal colon characters');
         }
 
@@ -69,7 +68,7 @@ class GoogleAuthenticator
         $otpauth = 'otpauth://' . $type . '/' . str_replace(array(':', ' '), array('%3A', '%20'), $label) . '?secret=' . rawurlencode($secret);
 
         if ($type == 'hotp' && !is_null($counter)) {
-            $otpauth .= '&counter=' . rawurlencode($counter);
+            $otpauth .= '&counter=' . intval($counter);
         }
 
         // Now check the options array
@@ -82,8 +81,10 @@ class GoogleAuthenticator
 
         // digits (currently ignored by Authenticator)
         // Defaults to 6
-        if (array_key_exists('digits', $options)) {
-            $otpauth .= '&digits=' . rawurlencode($options['digits']);
+        if (array_key_exists('digits', $options) && intval($options['digits']) !== 6 && intval($options['digits']) !== 8) {
+        	throw new \InvalidArgumentException('Digits can only have the values 6 or 8, ' . $options['digits'] . ' given');
+        } elseif (array_key_exists('digits', $options)) {
+            $otpauth .= '&digits=' . intval($options['digits']);
         }
 
         // period, only for totp (currently ignored by Authenticator)

--- a/tests/Otp/GoogleAuthenticatorTest.php
+++ b/tests/Otp/GoogleAuthenticatorTest.php
@@ -48,11 +48,29 @@ class GoogleAuthenticatorTest extends \PHPUnit_Framework_TestCase
 			'otpauth://totp/user@host.com?secret=MEP3EYVA6XNFNVNM',
 			GoogleAuthenticator::getKeyUri('totp', 'user@host.com', $secret)
 		);
-		
+
 		// hotp (include a counter)
 		$this->assertEquals(
 			'otpauth://hotp/user@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
 			GoogleAuthenticator::getKeyUri('hotp', 'user@host.com', $secret, 1234)
+		);
+
+		// totp/hotp with an issuer in the label
+		$this->assertEquals(
+			'otpauth://hotp/issuer%3Auser@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
+			GoogleAuthenticator::getKeyUri('hotp', 'issuer:user@host.com', $secret, 1234)
+		);
+
+		// totp/hotp with an issuer and spaces in the label
+		$this->assertEquals(
+			'otpauth://hotp/an%20issuer%3A%20user@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
+			GoogleAuthenticator::getKeyUri('hotp', 'an issuer: user@host.com', $secret, 1234)
+		);
+
+		// totp/hotp with an issuer as option
+		$this->assertEquals(
+			'otpauth://hotp/an%20issuer%3Auser@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234&issuer=an%20issuer',
+			GoogleAuthenticator::getKeyUri('hotp', 'an issuer:user@host.com', $secret, 1234, array('issuer' => 'an issuer'))
 		);
 	}
 	


### PR DESCRIPTION
The label and parameters of the key uri are not being escapet according to the spec: https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label

* added correct escaping of parameters in key uri
* added special case escaping for spaces in the label
* added test cases