### PR TITLE
The Google Authenticator app is no longer open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Implements hotp according to [RFC4226](https://tools.ietf.org/html/rfc4226) and 
 Class GoogleAuthenticator
 -------------------------
 
-Static function class to generate a correct url for the QR code, so you can easy scan it with your device. Google Authenticator is opensource and avaiaible as application for iPhone and Android. This removes the burden to create such an app from the developers of websites by using this set of classes.
+Static function class to generate a correct url for the QR code, so you can easy scan it with your device. Google Authenticator is avaiaible as application for iPhone and Android. This removes the burden to create such an app from the developers of websites by using this set of classes.
+
+There are also older open source versions of the Google Authenticator app for both [iPhone](https://github.com/google/google-authenticator) and [Android](https://github.com/google/google-authenticator-android)
 
 About
 =====


### PR DESCRIPTION
FreeOTP is another version of the old open source Google Authenticator app.
