### PR TITLE
Add support for a time offset

### DIFF
--- a/src/Otp.php
+++ b/src/Otp.php
@@ -56,6 +56,13 @@ class Otp implements OtpInterface
      * @var string
      */
     protected $algorithm = 'sha1';
+
+    /**
+     * Time offset between system time and GMT in seconds
+     *
+     * @var integer
+     */
+    protected $totpOffset = 0;
     
     /* (non-PHPdoc)
      * @see Otp.OtpInterface::hotp()
@@ -252,6 +259,34 @@ class Otp implements OtpInterface
     {
         return $this->digits;
     }
+
+    /**
+     * Set offset between system time and GMT
+     *
+     * @param integer $offset GMT - time()
+     * @throws \InvalidArgumentException
+     * @return \Otp\Otp
+     */
+    public function setTotpOffset($offset)
+    {
+        if (!is_int($offset)) {
+            throw new \InvalidArgumentException('Offset must be an integer');
+        }
+        
+        $this->totpOffset = $offset;
+        
+        return $this;
+    }
+    
+    /**
+     * Returns offset between system time and GMT in seconds
+     *
+     * @return integer
+     */
+    public function getTotpOffset()
+    {
+        return $this->totpOffset;
+    }
     
     /**
      * Generates a binary counter for hashing
@@ -275,7 +310,7 @@ class Otp implements OtpInterface
      */
     private function getTimecounter()
     {
-        return floor(time() / $this->period);
+        return floor((time() + $this->totpOffset) / $this->period);
     }
     
     /**


### PR DESCRIPTION
I happen to have an installation of nextcloud, which uses totp, on a webhosting platform where the provider does apparently not care to keep the system clock synchronized. Therefore, I need some way to fix the time used for the one time password. Otp could support setting an offset (the calling library can handle the actual comparison to ntp or whatever, I think this is outside of the scope of this library) that is added to the call to time().

There are security implications: An attacker that controls this offset could use basically any password they like. It would be the calling libraries' job to prevent that, but since the execution is strictly server-sided, I do not see an immediate attack vector.