### PR TITLE
Fix encoding of special characters in the label

### DIFF
--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -66,7 +66,7 @@ class GoogleAuthenticator
         }
 
         // This is the base, these are at least required
-        $otpauth = 'otpauth://' . $type . '/' . str_replace(array(':', ' '), array('%3A', '%20'), $label) . '?secret=' . rawurlencode($secret);
+        $otpauth = 'otpauth://' . $type . '/' . rawurlencode($label) . '?secret=' . rawurlencode($secret);
 
         if ($type == 'hotp' && !is_null($counter)) {
             $otpauth .= '&counter=' . intval($counter);

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -19,19 +19,19 @@ class GoogleAuthenticatorTest extends TestCase
 		
 		// Standard totp case
 		$this->assertEquals(
-			'https://chart.googleapis.com/chart?chs=200x200&cht=qr&chld=M|0&chl=otpauth%3A%2F%2Ftotp%2Fuser%40host.com%3Fsecret%3DMEP3EYVA6XNFNVNM',
+			'https://chart.googleapis.com/chart?chs=200x200&cht=qr&chld=M|0&chl=otpauth%3A%2F%2Ftotp%2Fuser%2540host.com%3Fsecret%3DMEP3EYVA6XNFNVNM',
 			GoogleAuthenticator::getQrCodeUrl('totp', 'user@host.com', $secret)
 		);
 		
 		// hotp (include a counter)
 		$this->assertEquals(
-			'https://chart.googleapis.com/chart?chs=200x200&cht=qr&chld=M|0&chl=otpauth%3A%2F%2Fhotp%2Fuser%40host.com%3Fsecret%3DMEP3EYVA6XNFNVNM%26counter%3D1234',
+			'https://chart.googleapis.com/chart?chs=200x200&cht=qr&chld=M|0&chl=otpauth%3A%2F%2Fhotp%2Fuser%2540host.com%3Fsecret%3DMEP3EYVA6XNFNVNM%26counter%3D1234',
 			GoogleAuthenticator::getQrCodeUrl('hotp', 'user@host.com', $secret, 1234)
 		);
 		
 		// totp, this time with a parameter for chaning the size of the QR
 		$this->assertEquals(
-				'https://chart.googleapis.com/chart?chs=300x300&cht=qr&chld=M|0&chl=otpauth%3A%2F%2Ftotp%2Fuser%40host.com%3Fsecret%3DMEP3EYVA6XNFNVNM',
+				'https://chart.googleapis.com/chart?chs=300x300&cht=qr&chld=M|0&chl=otpauth%3A%2F%2Ftotp%2Fuser%2540host.com%3Fsecret%3DMEP3EYVA6XNFNVNM',
 				GoogleAuthenticator::getQrCodeUrl('totp', 'user@host.com', $secret, null, array('height' => 300, 'width' => 300))
 		);
 		
@@ -46,31 +46,31 @@ class GoogleAuthenticatorTest extends TestCase
 		
 		// Standard totp case
 		$this->assertEquals(
-			'otpauth://totp/user@host.com?secret=MEP3EYVA6XNFNVNM',
+			'otpauth://totp/user%40host.com?secret=MEP3EYVA6XNFNVNM',
 			GoogleAuthenticator::getKeyUri('totp', 'user@host.com', $secret)
 		);
 
 		// hotp (include a counter)
 		$this->assertEquals(
-			'otpauth://hotp/user@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
+			'otpauth://hotp/user%40host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
 			GoogleAuthenticator::getKeyUri('hotp', 'user@host.com', $secret, 1234)
 		);
 
 		// totp/hotp with an issuer in the label
 		$this->assertEquals(
-			'otpauth://hotp/issuer%3Auser@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
+			'otpauth://hotp/issuer%3Auser%40host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
 			GoogleAuthenticator::getKeyUri('hotp', 'issuer:user@host.com', $secret, 1234)
 		);
 
 		// totp/hotp with an issuer and spaces in the label
 		$this->assertEquals(
-			'otpauth://hotp/an%20issuer%3A%20user@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
+			'otpauth://hotp/an%20issuer%3A%20user%40host.com?secret=MEP3EYVA6XNFNVNM&counter=1234',
 			GoogleAuthenticator::getKeyUri('hotp', 'an issuer: user@host.com', $secret, 1234)
 		);
 
 		// totp/hotp with an issuer as option
 		$this->assertEquals(
-			'otpauth://hotp/an%20issuer%3Auser@host.com?secret=MEP3EYVA6XNFNVNM&counter=1234&issuer=an%20issuer',
+			'otpauth://hotp/an%20issuer%3Auser%40host.com?secret=MEP3EYVA6XNFNVNM&counter=1234&issuer=an%20issuer',
 			GoogleAuthenticator::getKeyUri('hotp', 'an issuer:user@host.com', $secret, 1234, array('issuer' => 'an issuer'))
 		);
 	}


### PR DESCRIPTION
I'm indirectly using this nice library because it's shipped with XenForo. I think I've found a bug with labels that contain special characters like question marks.

The library should URL-encode all special characters (instead of only the colon and the space character). This is necessary because otherwise the generated URL is invalid if the label contains other special characters like for example a question mark.

I think this is in alignment with what the specification says: "The label is used to identify which account a key is associated with. It contains an account name, which is a URI-encoded string, optionally prefixed by an issuer string identifying the provider or service managing that account."

https://github.com/google/google-authenticator/wiki/Key-Uri-Format