### PR TITLE
require >=1 of paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4.0",
         "paragonie/constant_time_encoding": "^1|^2",
-        "paragonie/random_compat": "^1|^2",
+        "paragonie/random_compat": ">=1",
         "symfony/polyfill-php56": "^1"
     },
     "require-dev": {


### PR DESCRIPTION
This allows installation of version 9.99.99 not doing anything for
PHP 7. See https://github.com/paragonie/random_compat#version-conflict-with-other-php-project