### PR TITLE
Avoid counter reuse

### DIFF
--- a/src/Otp.php
+++ b/src/Otp.php
@@ -128,7 +128,7 @@ class Otp implements OtpInterface
     /* (non-PHPdoc)
      * @see Otp.OtpInterface::checkTotp()
     */
-    public function checkTotp($secret, $key, $timedrift = 1, $minTimeCounter = -1)
+    public function checkTotp($secret, $key, $timedrift = 1, $minTimeCounter = -1, &$newTimeCounter = null)
     {
         if (!is_numeric($timedrift) || $timedrift < 0) {
             throw new \InvalidArgumentException('Invalid timedrift supplied');
@@ -148,6 +148,7 @@ class Otp implements OtpInterface
     
         // We first try the current, as it is the most likely to work
         if ($timecounter > $minTimeCounter && hash_equals($this->totp($secret, $timecounter), $key)) {
+            $newTimeCounter = $timecounter;
             return true;
         } elseif ($timedrift == 0) {
             // When timedrift is 0, this is the end of the checks
@@ -167,6 +168,7 @@ class Otp implements OtpInterface
             }
                 
             if (hash_equals($this->totp($secret, $t), $key)) {
+                $newTimeCounter = $timecounter;
                 return true;
             }
         }

--- a/src/OtpInterface.php
+++ b/src/OtpInterface.php
@@ -67,11 +67,12 @@ interface OtpInterface
     /**
      * Checks Totp agains a key
      *
-     * @param string  $secret    Base32 Secret String
-     * @param integer $key       User supplied key
-     * @param integer $timedrift How large a drift to use beyond exact match
+     * @param string  $secret         Base32 Secret String
+     * @param integer $key            User supplied key
+     * @param integer $timedrift      How large a drift to use beyond exact match
+     * @param integer $minTimeCounter The smallest timecode that is accepted
      *
      * @return boolean True if key is correct within time drift
      */
-    function checkTotp($secret, $key, $timedrift = 1);
+    function checkTotp($secret, $key, $timedrift = 1, $minTimeCounter = -1);
 }

--- a/src/OtpInterface.php
+++ b/src/OtpInterface.php
@@ -70,9 +70,10 @@ interface OtpInterface
      * @param string  $secret         Base32 Secret String
      * @param integer $key            User supplied key
      * @param integer $timedrift      How large a drift to use beyond exact match
-     * @param integer $minTimeCounter The smallest timecode that is accepted
+     * @param integer $minTimeCounter The smallest timecounter that is accepted
+     * @param integer $newTimeCounter The new timecounter value
      *
      * @return boolean True if key is correct within time drift
      */
-    function checkTotp($secret, $key, $timedrift = 1, $minTimeCounter = -1);
+    function checkTotp($secret, $key, $timedrift = 1, $minTimeCounter = -1, &$newTimeCounter = null);
 }


### PR DESCRIPTION
When using TOTP a prover can send the same OTP multiple times. Only the first one should be accepected as per the RFC.

This PR does  things

1. It makes it possible to obtain the timeCounter value by a caller. This can then be stored.
2. It makes it possible to supply a minTimeCounter 

When used in combination it becomes a easy to enforce the OTP to always move forward. The caller just has to store the latest timeCounter along with the secret and supply it when calling checkTotp.