### PR TITLE
Correct PHPdoc of checkTotp key parameter

### DIFF
--- a/src/OtpInterface.php
+++ b/src/OtpInterface.php
@@ -68,7 +68,7 @@ interface OtpInterface
      * Checks Totp agains a key
      *
      * @param string  $secret    Base32 Secret String
-     * @param integer $key       User supplied key
+     * @param string  $key       User supplied key
      * @param integer $timedrift How large a drift to use beyond exact match
      *
      * @return boolean True if key is correct within time drift


### PR DESCRIPTION
`checkTotp` `$key` is usually something like a 6-digit numeric. But it can start with `0` - e.g. `012345` or maybe even `006789` are possible OTPs. So it is not always a "PHP integer".

We noticed this in https://github.com/owncloud/twofactor_totp/pull/182/files#diff-d198ab4b1f668b66bd9f97d14160cdc2L122 where we had explicitly cast to `int` to match the PHPdoc of `checkTotp` (and keep code analysis tools happy). That caused intermittent fails, because sometimes the OTP had a leading `0`.