### PR TITLE
Remove support for PHP 5.4 and 5.5 because of hash_equals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: false
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ matrix:
         - nightly
 
 before_script:
-    - composer install
-
-before_script:
     - composer install --no-interaction
     - mkdir -p build/logs
 

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "paragonie/constant_time_encoding": "^1|^2",
         "paragonie/random_compat": ">=1",
         "symfony/polyfill-php56": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.0.5"
+        "phpunit/phpunit": "^5.7.11 || ^6.0.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`hash_equals` is used in the code, and it only exists for PHP 5.6 onward. So adjust `composer.json` and `.travis.yml` to reflect this.