### PR TITLE
[CR-4720][BackOffice] Addressing Google Authenticator deprecation-use fork repository

### DIFF
--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -125,25 +125,9 @@ class GoogleAuthenticator
      */
     public static function getQrCodeUrl($type, $label, $secret, $counter = null, $options = array())
     {
-        // Width and height can be overwritten
-        $width = self::$width;
-
-        if (array_key_exists('width', $options) && is_numeric($options['width'])) {
-            $width = $options['width'];
-        }
-
-        $height = self::$height;
-
-        if (array_key_exists('height', $options) && is_numeric($options['height'])) {
-            $height = $options['height'];
-        }
-
         $otpauth = self::getKeyUri($type, $label, $secret, $counter, $options);
 
-        $url = 'https://chart.googleapis.com/chart?chs=' . $width . 'x'
-             . $height . '&cht=qr&chld=M|0&chl=' . urlencode($otpauth);
-
-        return $url;
+        return 'https://qrcode.tec-it.com/API/QRCode?size=small&data='. urlencode($otpauth);
     }
 
     /**


### PR DESCRIPTION
Since the Google Authenticator Laravel plugin relies on the deprecated chart.googleapis.com service, its usage is no longer recommended. So we  integrating a forked repository from ChristianRiesen/otp, ensuring uninterrupted service and bolstering the security of accounts and also here are the changes. 

### Old QR Code Generation:
**php**
```
$url = 'https://chart.googleapis.com/chart?chs=' . $width . 'x'
             . $height . '&cht=qr&chld=M|0&chl=' . urlencode($otpauth);
```
### New and Improved QR Code Generation:
**php**
`return 'https://qrcode.tec-it.com/API/QRCode?size=small&data='. urlencode($otpauth);`
This streamlined approach ensures that your authentication process remains seamless, efficient, and, most importantly, secure. 
